### PR TITLE
PolyOpt2: Delete useless variable declarations, Have make check generate files in top_builddir/tests

### DIFF
--- a/projects/PolyOpt2/ChangeLog
+++ b/projects/PolyOpt2/ChangeLog
@@ -1,5 +1,34 @@
 2017-06-23  Louis-Noel Pouchet  <pouchet@colostate.edu>
 
+	* projects/PolyOpt2/tests/Makefile.am,
+	* projects/PolyOpt2/tests/scripts/checker.sh: Update to run make check
+	in builddir (no more modification of srcdir).
+
+	* projects/PolyOpt2/tests/unitary/assigniter.passthru.c,
+	* projects/PolyOpt2/tests/unitary/assigniter2.passthru.c,
+	* projects/PolyOpt2/tests/unitary/basicnest.passthru.c,
+	* projects/PolyOpt2/tests/unitary/binop.passthru.c,
+	* projects/PolyOpt2/tests/unitary/classicloop.passthru.c,
+	* projects/PolyOpt2/tests/unitary/comments.passthru.c,
+	* projects/PolyOpt2/tests/unitary/complexcond.passthru.c,
+	* projects/PolyOpt2/tests/unitary/complexop.passthru.c,
+	* projects/PolyOpt2/tests/unitary/field.passthru.c,
+	* projects/PolyOpt2/tests/unitary/functioncall2.passthru.c,
+	* projects/PolyOpt2/tests/unitary/intaddit.passthru.c,
+	* projects/PolyOpt2/tests/unitary/negassign.passthru.c,
+	* projects/PolyOpt2/tests/unitary/parenthesis.passthru.c,
+	* projects/PolyOpt2/tests/unitary/redefiter.passthru.c,
+	* projects/PolyOpt2/tests/unitary/simplecond.passthru.c,
+	* projects/PolyOpt2/tests/unitary/simpleloop.passthru.c,
+	* projects/PolyOpt2/tests/unitary/ternary.passthru.c,
+	* projects/PolyOpt2/tests/unitary/twocondincond.passthru.c,
+	* projects/PolyOpt2/tests/unitary/twoconds.passthru.c,
+	* projects/PolyOpt2/tests/unitary/underscore.passthru.c: Update test suite
+	to be compliant with new removal of useless variable declarations after polyopt
+	transformation.
+
+2017-06-23  Louis-Noel Pouchet  <pouchet@colostate.edu>
+
 	* projects/PolyOpt2/tests/scripts/checker.sh: update to loosen
 	constraints on the order of iterator declaration.
 

--- a/projects/PolyOpt2/polyopt/include/polyopt/PolyOpt.hpp
+++ b/projects/PolyOpt2/polyopt/include/polyopt/PolyOpt.hpp
@@ -66,6 +66,13 @@ PolyOptRecognizeScopsSubTree(SgNode* root, PolyRoseOptions& polyoptions);
 PolyOptISLRepresentation
 PolyOptConvertScopToISL(scoplib_scop_p scop);
 
+/**
+ * Cleans the function (n, or the one enclosing n) from useless variable 
+ * declarations.
+ *
+ */
+void
+PolyOptCleanUselessVariableDeclarations(SgNode* n);
 
 
 

--- a/projects/PolyOpt2/tests/Makefile.am
+++ b/projects/PolyOpt2/tests/Makefile.am
@@ -12,7 +12,7 @@ SUBDIRS 		=
 #############################################################################
 MAINTAINERCLEANFILES    = Makefile.in
 
-TESTS_ENVIRONMENT       = top_builddir=$(top_builddir)
+TESTS_ENVIRONMENT       = top_builddir=$(top_builddir) top_srcdir=$(top_srcdir)
 
 EXTRA_DIST              = scripts/checker.sh
 #############################################################################

--- a/projects/PolyOpt2/tests/scripts/checker.sh
+++ b/projects/PolyOpt2/tests/scripts/checker.sh
@@ -5,19 +5,21 @@
 ## Contact: <louis-noel.pouchet@inria.fr>
 ##
 ## Started on  Sat Jul 18 16:57:09 2009 Louis-Noel Pouchet
-## Last update Fri Jun 23 05:37:16 2017 Louis-Noel Pouchet
+## Last update Mon Jul  3 12:04:32 2017 Louis-Noel Pouchet
 ##
 
 output=0
 TEST_FILES="$2";
 echo "[CHECK] $1";
 mode="$3";
-TESTS_PREFIX_SRC="$top_srcdir/tests"
-TESTS_PREFIX_BLD="$top_builddir/tests"
+TESTS_PREFIX_SRC="$top_srcdir/tests/unitary";
+TESTS_PREFIX_BLD="$top_builddir/tests";
+if ! [ -d "$TESTS_PREFIX_BLD" ]; then mkdir -p "$TESTS_PREFIX_BLD"; fi;
 for i in $TEST_FILES; do
     outtemp=0;
     echo "[TEST] == $i ==";
     filename=${i%.c};
+    filename=`basename "$filename"`;
     case "$mode" in
 	passthru) outfile="$filename.passthru"; options="";;
 	tile) outfile="$filename.plutotile"; options="--polyopt-pluto-tile";;
@@ -29,11 +31,15 @@ for i in $TEST_FILES; do
     esac;
     ## (1) Check that generated files are the same.
 #    $top_builddir/src/PolyRose $options $TESTS_PREFIX_SRC/$i -rose:o $TESTS_PREFIX_BLD/$outfile.test.c 2>/tmp/poccout >/dev/null
- #   z=`diff --ignore-matching-lines='CLooG' --ignore-matching-lines='rose\[WARN' --ignore-matching-lines='int c' --ignore-blank-lines $TESTS_PREFIX_BLD/$outfile.test.c $TESTS_PREFIX_SRC/$outfile.c 2>&1`
+    #   z=`diff --ignore-matching-lines='CLooG' --ignore-matching-lines='rose\[WARN' --ignore-matching-lines='int c' --ignore-blank-lines $TESTS_PREFIX_BLD/$outfile.test.c $TESTS_PREFIX_SRC/$outfile.c 2>&1`
+    prototype_name="$outfile";
+    outfile="$TESTS_PREFIX_BLD/$prototype_name";
+    reffile="$TESTS_PREFIX_SRC/$prototype_name";
     $top_builddir/src/PolyRose $options $i -rose:o $outfile.test.c 2>/tmp/poccout >/dev/null
-    z=`diff --ignore-matching-lines='CLooG' --ignore-matching-lines='rose\[WARN' --ignore-matching-lines='int c' --ignore-blank-lines $outfile.test.c $outfile.c 2>&1`
+    z=`diff --ignore-matching-lines='CLooG' --ignore-matching-lines='rose\[WARN' --ignore-matching-lines='int c' --ignore-blank-lines --ignore-space-change --ignore-all-space $outfile.test.c $reffile.c 2>&1`
     err=`cat /tmp/poccout | grep -v "\[CLooG\] INFO:"`;
     if ! [ -z "$z" ]; then
+	echo "DEBUG: diff output:[BEGIN] $z [END]";
 	echo "\033[31m[FAIL] PoCC -> generated codes are different\033[0m";
 	outtemp=1;
 	output=1;
@@ -45,7 +51,7 @@ for i in $TEST_FILES; do
     fi;
     ## (2) Check that the generated files do compile
 #    rm -f /tmp/poccout;
-    z=`gcc $TESTS_PREFIX/$outfile.test.c -o $TESTS_PREFIX/a.out 2>&1`;
+    z=`gcc $outfile.test.c -o $outfile.test.bin 2>&1`;
     ret="$?";
     gcchasnoomp=`echo "$z" | grep "error: omp.h: No such file"`;
     numlines=`echo "$z" | wc -l`;
@@ -63,7 +69,7 @@ for i in $TEST_FILES; do
     if [ "$outtemp" -eq 0 ]; then
 	echo "[PASS] $i";
     fi;
-    rm -f $TESTS_PREFIX/a.out;
+    rm -f $outfile.test.bin;
 done
 if [ "$output" -eq 1 ]; then
     echo "\033[31m[FAIL] $1\033[0m";

--- a/projects/PolyOpt2/tests/unitary/assigniter.passthru.c
+++ b/projects/PolyOpt2/tests/unitary/assigniter.passthru.c
@@ -1,8 +1,6 @@
 
 int main()
 {
-  int i;
-  int j;
   int N;
   int A[N];
   

--- a/projects/PolyOpt2/tests/unitary/assigniter2.passthru.c
+++ b/projects/PolyOpt2/tests/unitary/assigniter2.passthru.c
@@ -1,8 +1,6 @@
 
 int main()
 {
-  int i;
-  int j;
   int N;
   int A[N][N];
   

--- a/projects/PolyOpt2/tests/unitary/basicnest.passthru.c
+++ b/projects/PolyOpt2/tests/unitary/basicnest.passthru.c
@@ -1,8 +1,6 @@
 
 int main()
 {
-  int i;
-  int j;
   int n;
   int a;
   int c;

--- a/projects/PolyOpt2/tests/unitary/binop.passthru.c
+++ b/projects/PolyOpt2/tests/unitary/binop.passthru.c
@@ -4,7 +4,6 @@ int main()
   int a;
   int b;
   int n;
-  int i;
   
 #pragma scop
 {

--- a/projects/PolyOpt2/tests/unitary/classicloop.passthru.c
+++ b/projects/PolyOpt2/tests/unitary/classicloop.passthru.c
@@ -1,7 +1,6 @@
 
 int main()
 {
-  int i;
   int n;
   int a;
   

--- a/projects/PolyOpt2/tests/unitary/comments.passthru.c
+++ b/projects/PolyOpt2/tests/unitary/comments.passthru.c
@@ -1,7 +1,6 @@
 
 int main()
 {
-  int i;
   int n;
   int c[n];
   

--- a/projects/PolyOpt2/tests/unitary/complexcond.passthru.c
+++ b/projects/PolyOpt2/tests/unitary/complexcond.passthru.c
@@ -1,7 +1,6 @@
 
 int main()
 {
-  int i;
   int n;
   int a;
   int b;

--- a/projects/PolyOpt2/tests/unitary/complexop.passthru.c
+++ b/projects/PolyOpt2/tests/unitary/complexop.passthru.c
@@ -5,7 +5,6 @@ int main()
   int b;
   int c;
   int n;
-  int i;
   int d[n];
   
 #pragma scop

--- a/projects/PolyOpt2/tests/unitary/field.passthru.c
+++ b/projects/PolyOpt2/tests/unitary/field.passthru.c
@@ -8,7 +8,6 @@ struct s
 
 int main()
 {
-  int i;
   int N;
   int d;
   struct s a;

--- a/projects/PolyOpt2/tests/unitary/functioncall2.passthru.c
+++ b/projects/PolyOpt2/tests/unitary/functioncall2.passthru.c
@@ -2,7 +2,6 @@
 
 int main()
 {
-  int i;
   int n;
   
 #pragma scop

--- a/projects/PolyOpt2/tests/unitary/intaddit.passthru.c
+++ b/projects/PolyOpt2/tests/unitary/intaddit.passthru.c
@@ -1,8 +1,6 @@
 
 int main()
 {
-  int i;
-  int j;
   int N;
   int b[N][N];
   int a[N][N];

--- a/projects/PolyOpt2/tests/unitary/negassign.passthru.c
+++ b/projects/PolyOpt2/tests/unitary/negassign.passthru.c
@@ -1,7 +1,6 @@
 
 int main()
 {
-  int k;
   int N;
   int alpha;
   int sum;

--- a/projects/PolyOpt2/tests/unitary/parenthesis.passthru.c
+++ b/projects/PolyOpt2/tests/unitary/parenthesis.passthru.c
@@ -1,7 +1,6 @@
 
 int main()
 {
-  int i;
   int N;
   int A[N];
   int B[N];

--- a/projects/PolyOpt2/tests/unitary/redefiter.passthru.c
+++ b/projects/PolyOpt2/tests/unitary/redefiter.passthru.c
@@ -1,9 +1,6 @@
 
 int main()
 {
-  int t;
-  int i;
-  int j;
   int Ca;
   int b;
   int N;

--- a/projects/PolyOpt2/tests/unitary/simplecond.passthru.c
+++ b/projects/PolyOpt2/tests/unitary/simplecond.passthru.c
@@ -1,7 +1,6 @@
 
 int main()
 {
-  int i;
   int n;
   int a;
   

--- a/projects/PolyOpt2/tests/unitary/simpleloop.passthru.c
+++ b/projects/PolyOpt2/tests/unitary/simpleloop.passthru.c
@@ -1,7 +1,6 @@
 
 int main()
 {
-  int i;
   int n;
   int a;
   

--- a/projects/PolyOpt2/tests/unitary/ternary.passthru.c
+++ b/projects/PolyOpt2/tests/unitary/ternary.passthru.c
@@ -1,7 +1,6 @@
 
 int main()
 {
-  int i;
   int n;
   int b;
   int c;

--- a/projects/PolyOpt2/tests/unitary/twocondincond.passthru.c
+++ b/projects/PolyOpt2/tests/unitary/twocondincond.passthru.c
@@ -8,7 +8,6 @@ int main()
   int a;
   int b;
   int c;
-  int i;
   
 #pragma scop
 {

--- a/projects/PolyOpt2/tests/unitary/twoconds.passthru.c
+++ b/projects/PolyOpt2/tests/unitary/twoconds.passthru.c
@@ -5,7 +5,6 @@ int main()
   int N;
   int a;
   int b;
-  int i;
   
 #pragma scop
 {

--- a/projects/PolyOpt2/tests/unitary/underscore.passthru.c
+++ b/projects/PolyOpt2/tests/unitary/underscore.passthru.c
@@ -1,11 +1,8 @@
 
 int main()
 {
-  int i;
   int M;
   int N;
-  int j;
-  int k;
   int K;
   int C[N][N];
   int _C_[N][N];


### PR DESCRIPTION
1) Add function projects/PolyOpt2/polyopt/PolyOpt.cpp:PolyOptCleanUselessVariableDeclarations() to remove variable declarations made useless after transformation. Note: tested only for C language, but should be quite robust. Called by default when running PolyOpt's main optimization stage.

2) Change make check to generate files only in $top_builddir/projects/PolyOpt2/tests. Update test suite for compliance with new PolyOptCleanUselessVariableDeclarations() modifications.